### PR TITLE
Pin npm package versions - SOP-1331

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,24 +9,24 @@
   },
   "homepage": "https://github.com/Landscape-Management-Network/api-style-guide#readme",
   "devDependencies": {
-    "@stoplight/spectral-core": "~1.19.1",
-    "@stoplight/spectral-parsers": "~1.0.4",
-    "@stoplight/spectral-ruleset-bundler": "~1.6.0",
-    "@stoplight/spectral-runtime": "~1.1.2",
+    "@stoplight/spectral-core": "1.19.1",
+    "@stoplight/spectral-parsers": "1.0.4",
+    "@stoplight/spectral-ruleset-bundler": "1.6.0",
+    "@stoplight/spectral-runtime": "1.1.2",
     "@types/chai": "4.2.21",
-    "@types/mocha": "~10.0.9",
+    "@types/mocha": "10.0.9",
     "chai": "4.3.4",
-    "eslint": "^9.11.1",
-    "eslint-config-decent": "^2.2.2",
-    "husky": "^9.1.6",
-    "lint-staged": "^15.2.10",
-    "markdownlint-cli": "^0.42.0",
-    "mocha": "~10.7.3",
-    "npm-run-all": "~4.1.5",
-    "openapi-types": "~12.1.3",
-    "prettier": "^3.3.3",
-    "ts-node": "~10.9.2",
-    "typescript": "^5.6.2"
+    "eslint": "9.12.0",
+    "eslint-config-decent": "2.2.2",
+    "husky": "9.1.6",
+    "lint-staged": "15.2.10",
+    "markdownlint-cli": "0.42.0",
+    "mocha": "10.7.3",
+    "npm-run-all": "4.1.5",
+    "openapi-types": "12.1.3",
+    "prettier": "3.3.3",
+    "ts-node": "10.9.2",
+    "typescript": "5.6.2"
   },
   "scripts": {
     "test": "mocha --loader=ts-node/esm tests/**/*.tests.ts",
@@ -37,9 +37,18 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "*.md": ["prettier --write --cache", "markdownlint --config=.github/linters/.markdown-lint.yml --fix"],
-    "!(package-lock).json": ["prettier --write"],
-    "*.{yml,yaml}": ["eslint --fix"],
-    "*.{js,cjs,mjs,ts,tsx}": ["eslint --fix"]
+    "*.md": [
+      "prettier --write --cache",
+      "markdownlint --config=.github/linters/.markdown-lint.yml --fix"
+    ],
+    "!(package-lock).json": [
+      "prettier --write"
+    ],
+    "*.{yml,yaml}": [
+      "eslint --fix"
+    ],
+    "*.{js,cjs,mjs,ts,tsx}": [
+      "eslint --fix"
+    ]
   }
 }


### PR DESCRIPTION
## Package Version Pinning

This PR pins all npm package versions to their currently installed versions as specified in package-lock.json.

**Changes:**
- All dependencies and devDependencies have been locked to exact versions
- Removed version ranges (^, ~, etc.) to ensure reproducible builds
- All packages have been verified to be free of known vulnerabilities

**Related Issue:** SOP-1331 - Pin npm package versions

**Verification:**
- ✅ package-lock.json present
- ✅ No vulnerabilities detected
- ✅ All packages pinned to exact versions